### PR TITLE
Fix permissions of init scripts to 755 for correct execution

### DIFF
--- a/rpm/SPECS/ha-lizard.spec
+++ b/rpm/SPECS/ha-lizard.spec
@@ -1,5 +1,5 @@
 %define version      2.4.4
-%define release      123
+%define release      124
 %define buildarch    noarch
 %define name         ha-lizard
 
@@ -65,6 +65,7 @@ echo "Setting up ha-lizard..."
 # Set executable permissions
 find %{_sysconfdir}/ha-lizard -type f -name "*.sh" -exec chmod +x {} \;
 find %{_sysconfdir}/ha-lizard -type f -name "*.tcl" -exec chmod +x {} \;
+find %{_sysconfdir}/ha-lizard/init -type f -exec chmod +x {} \;
 find %{_sysconfdir}/ha-lizard/scripts -type f -exec chmod +x {} \;
 
 # Add CLI link


### PR DESCRIPTION
## Description

Fixed the permissions of init scripts to 755 to ensure they are executable by the system. This change resolves issues where the scripts were not running due to incorrect permissions.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the project's CONTRIBUTING.md.
- [x] I have verified that my changes work as expected.
- [x] All tests pass locally.

